### PR TITLE
修复TnInput type='select'时 H5环境下无法点击 fix #76

### DIFF
--- a/components/input/src/input.vue
+++ b/components/input/src/input.vue
@@ -39,6 +39,7 @@ const {
   <view
     :class="[
       inputClass,
+      `${type === 'select' ? ns.m('select') : ns.m('input')}`,
       `${type === 'textarea' ? ns.m('textarea') : ns.m('input')}`,
       ns.is('show-word-limit', showWordLimit),
     ]"

--- a/theme-chalk/src/input.scss
+++ b/theme-chalk/src/input.scss
@@ -66,6 +66,16 @@ $input-sizes: map-merge(
     font-size: inherit;
   }
 
+  /* 输入框类型select start */
+  @include m(select) {
+    /* #ifdef H5 */
+    :deep(.uni-input-input){
+      z-index: -1;
+    }
+    /* #endif */
+  }
+  /* 输入框类型select end */
+
   @include e(textarea) {
     @include when(custom-height) {
       height: 100%;


### PR DESCRIPTION
已测试H5、微信小程序、原生APP云打包正常使用