### PR TITLE
fix: 适配头条系小程序

### DIFF
--- a/components/button/src/button.vue
+++ b/components/button/src/button.vue
@@ -32,6 +32,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <button

--- a/components/collapse/src/collapse-item.vue
+++ b/components/collapse/src/collapse-item.vue
@@ -25,6 +25,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view

--- a/components/icon/src/icon.vue
+++ b/components/icon/src/icon.vue
@@ -30,6 +30,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view :class="[iconClass]" :style="iconStyle" @tap="handleClick">

--- a/components/index-list/src/index-list.vue
+++ b/components/index-list/src/index-list.vue
@@ -33,6 +33,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view :class="[ns.b()]" :style="{ height: `${contentContainerHeight}px` }">

--- a/components/lazy-load/src/lazy-load.vue
+++ b/components/lazy-load/src/lazy-load.vue
@@ -26,6 +26,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view

--- a/components/loading/src/loading.vue
+++ b/components/loading/src/loading.vue
@@ -23,6 +23,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view v-if="show" :class="[loadingClass]" :style="loadingStyle">

--- a/components/notice-bar/src/column-notice-bar.vue
+++ b/components/notice-bar/src/column-notice-bar.vue
@@ -18,6 +18,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view :class="[ns.b()]">

--- a/components/notice-bar/src/row-notice-bar.vue
+++ b/components/notice-bar/src/row-notice-bar.vue
@@ -17,6 +17,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view

--- a/components/steps/src/steps-item.vue
+++ b/components/steps/src/steps-item.vue
@@ -21,6 +21,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view :class="[stepClass]" :style="stepStyle">

--- a/components/subsection/src/subsection-item.vue
+++ b/components/subsection/src/subsection-item.vue
@@ -20,6 +20,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view

--- a/components/swipe-action/src/swipe-action-item.vue
+++ b/components/swipe-action/src/swipe-action-item.vue
@@ -33,6 +33,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view :id="componentId" :class="[ns.b()]">

--- a/components/swiper/src/swiper.vue
+++ b/components/swiper/src/swiper.vue
@@ -26,6 +26,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view :class="[ns.b()]" :style="swiperStyle" @tap.stop="itemClickHandle">

--- a/components/tabbar/src/tabbar-item.vue
+++ b/components/tabbar/src/tabbar-item.vue
@@ -29,6 +29,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view

--- a/components/tabs/src/tabs-item.vue
+++ b/components/tabs/src/tabs-item.vue
@@ -23,6 +23,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view

--- a/components/water-fall/src/water-fall.vue
+++ b/components/water-fall/src/water-fall.vue
@@ -27,6 +27,15 @@ export default {
 }
 </script>
 // #endif
+// #ifdef MP-TOUTIAO
+<script lang="ts">
+export default {
+  options: {
+    applyFragment: true,
+  },
+}
+</script>
+// #endif
 
 <template>
   <view :class="[ns.b()]">


### PR DESCRIPTION
接入头条系小程序时，原本适配微信的虚拟节点配置项不生效了。
所有flex元素下面的.flex-1的子元素都会缩起来。
抖音这里使用的是[`applyFragment`配置项](https://developer.open-douyin.com/docs/resource/zh-CN/mini-app/develop/framework/custom-component/component-model-and-style/#7417c627)
因此参考微信的配置对`#ifdef MP-TOUTIAO`做了适配。

这是迁移过程中目前遇到最明显但也最容易解决的问题。
可能后面还有不少坑要踩……比如tabbar的点击不生效了