### PR TITLE
FIX(switchTab): change to <slot></slot> to fix Framework inner error (expect START descriptor with depth 3 but get FLOW_DEPTH)

### DIFF
--- a/components/switch-tab/src/switch-tab.vue
+++ b/components/switch-tab/src/switch-tab.vue
@@ -27,7 +27,7 @@ const { ns, tabClass, tabStyle, switchTabClass, switchTabStyle } =
     </view>
     <!-- 内容区域 -->
     <view :class="[ns.e('content')]">
-      <slot />
+      <slot></slot>
     </view>
   </view>
 </template>


### PR DESCRIPTION
# Changes:
change to <slot></slot> to fix Framework inner error (expect START descriptor with depth 3 but get FLOW_DEPTH) in the mp-weixin